### PR TITLE
Build contrib, PL/Python  and XML dependencies

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -47,24 +47,24 @@ install:
 
     # Add path, activate `conda` and update conda.
     - cmd: call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
-    - cmd: conda update --yes --quiet conda
+    - cmd: conda.exe update --yes --quiet conda
 
     - cmd: set PYTHONUNBUFFERED=1
 
     # Add our channels.
-    - cmd: conda config --set show_channel_urls true
-    - cmd: conda config --remove channels defaults
-    - cmd: conda config --add channels defaults
-    - cmd: conda config --add channels conda-forge
+    - cmd: conda.exe config --set show_channel_urls true
+    - cmd: conda.exe config --remove channels defaults
+    - cmd: conda.exe config --add channels defaults
+    - cmd: conda.exe config --add channels conda-forge
 
     # Configure the VM.
-    - cmd: conda install -n root --quiet --yes conda-forge-build-setup
+    - cmd: conda.exe install -n root --quiet --yes conda-forge-build-setup
     - cmd: run_conda_forge_build_setup
 
 # Skip .NET project specific build phase.
 build: off
 
 test_script:
-    - conda build recipe --quiet
+    - conda.exe build recipe --quiet
 deploy_script:
     - cmd: upload_or_check_non_existence .\recipe conda-forge --channel=main

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -13,5 +13,5 @@ fi
     --with-gssapi
 
 make
-# make check # Failing with 'initdb: cannot be run as root'.
+make check
 make install

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -10,8 +10,15 @@ fi
     --with-libraries=$PREFIX/lib \
     --with-includes=$PREFIX/include \
     --with-openssl \
+    --with-python \
+    --with-uuid=e2fs \
+    --with-libxml \
     --with-gssapi
 
-make
+make -j $CPU_COUNT
+make -j $CPU_COUNT -C contrib
+
 make check
+
 make install
+make install -C contrib

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
 
 build:
   skip: True  # [win and py36]
-  number: 4
+  number: 5
   features:
     - vc9  # [win and py27]
     - vc14  # [win and (py35 or py36)]
@@ -32,13 +32,18 @@ requirements:
     - readline 7.0  # [not win]
     - zlib 1.2.11
     - krb5  # [not osx]
+    - libxml2 2.9.*
+    - libxslt 1.1.*
+    - libuuid 1.0.*  # [not win]
     - vc 9  # [win and py27]
     - vc 14  # [win and (py35 or py36)]
   run:
+    - python
     - openssl 1.0.*
     - readline 7.0  # [not win]
     - zlib 1.2.11
     - krb5  # [not osx]
+    - libxml2 2.9.*
     - vc 9  # [win and py27]
     - vc 14  # [win and (py35 or py36)]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -66,3 +66,4 @@ extra:
     - msarahan
     - ocefpaf
     - mariusvniekerk
+    - sodre

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,6 +44,8 @@ requirements:
     - zlib 1.2.11
     - krb5  # [not osx]
     - libxml2 2.9.*
+    - libxslt 1.1.*
+    - libuuid 1.0.*  # [not win]
     - vc 9  # [win and py27]
     - vc 14  # [win and (py35 or py36)]
 


### PR DESCRIPTION
- This PR would make the proposed `postgresql-contrib` package in
   conda-forge/staged-recipes#5073 obsolete. This means one
   less package to maintain and shorter build times.
 - Re-enabled `make check`, since the new docker-images run as the
   `conda` user.
 - Add PL/Python extension allowing us to program server side
   functions while using conda to control the package dependencies.
   Potential impact, calling conda-forge/scikit-learn directly 
   from Postgres.

ref: @ocefpaf, @mariusvniekerk, @bgruening, @Juanlu001