### PR TITLE
Only depend on readline for the binary, not the libraries

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ source:
     - patches/fix_auth_setenv_win.patch  # [win]
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win and float(vc) < 14]
 
 requirements:
@@ -106,7 +106,9 @@ outputs:
         # these are here for sake of run_exports taking effect
         - krb5     # [not osx]
         - openssl
-        - readline         # [not win]
+        # Readline is only a dependency of the executable psql
+        # included in the postgresql package
+        # - readline         # [not win]
         - zlib
         - {{ pin_subpackage('postgresql', exact=True) }}
         - python
@@ -119,7 +121,6 @@ outputs:
         - python
         - krb5
         - openssl
-        - readline         # [not win]
         - zlib
     script: install_plpython.sh  # [unix]
     test:
@@ -141,7 +142,9 @@ outputs:
         # these are here for sake of run_exports taking effect
         - krb5
         - openssl
-        - readline         # [not win]
+        # Readline is only a dependency of the executable psql
+        # included in the postgresql package
+        # - readline         # [not win]
         - tzcode          # [not win]
         - tzdata          # [not win]
         - zlib


### PR DESCRIPTION
Looking through the previous logs, it seems that readline is only required for the binary included in the postgresql package, not the library package.

@conda-forge-admin please rerender
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
