### PR TITLE
Reduce the dependency on readline

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ About postgresql-split
 
 Home: 
 
-Package license: 
+Package license: PostgreSQL
 
 Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/postgresql-feedstock/blob/main/LICENSE.txt)
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ source:
     - patches/fix_x509_name_win.patch  # [win]
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win and float(vc) < 14]
 
 requirements:
@@ -107,7 +107,9 @@ outputs:
         # these are here for sake of run_exports taking effect
         - krb5     # [not osx]
         - openssl
-        - readline         # [not win]
+        # Readline is only a dependency of the executable psql
+        # included in the postgresql package
+        # - readline         # [not win]
         - zlib
         - {{ pin_subpackage('postgresql', exact=True) }}
         - python
@@ -120,7 +122,6 @@ outputs:
         - python
         - krb5
         - openssl
-        - readline         # [not win]
         - zlib
     script: install_plpython.sh  # [unix]
     test:
@@ -142,7 +143,9 @@ outputs:
         # these are here for sake of run_exports taking effect
         - krb5
         - openssl
-        - readline         # [not win]
+        # Readline is only a dependency of the executable psql
+        # included in the postgresql package
+        # - readline         # [not win]
         - tzcode          # [not win]
         - tzdata          # [not win]
         - zlib

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -128,6 +128,8 @@ outputs:
       commands:
     about:
       summary: The plpythonu postgresql extension
+      license: PostgreSQL
+      license_file: COPYRIGHT
 
   - name: libpq
     build:
@@ -165,6 +167,8 @@ outputs:
         - IF NOT EXIST %LIBRARY_BIN%\pg_config.exe EXIT 1  # [win]
     about:
       summary: The postgres runtime libraries and utilities (not the server itself)
+      license: PostgreSQL
+      license_file: COPYRIGHT
 
 about:
   home: http://www.postgresql.org/


### PR DESCRIPTION
Looking through the previous logs, it seems that readline is only required for the binary included in the postgresql package, not the library package.

Closes #128 

@conda-forge-admin please rerender
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
