### PR TITLE
create intermediate build openssl 3.1 + libxml2 2.12

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -25,7 +25,7 @@ libuuid:
 libxml2:
 - '2.12'
 openssl:
-- '3'
+- '3.1'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -29,7 +29,7 @@ libuuid:
 libxml2:
 - '2.12'
 openssl:
-- '3'
+- '3.1'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -25,7 +25,7 @@ libuuid:
 libxml2:
 - '2.12'
 openssl:
-- '3'
+- '3.1'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -25,7 +25,7 @@ libxml2:
 macos_machine:
 - x86_64-apple-darwin13.4.0
 openssl:
-- '3'
+- '3.1'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -25,7 +25,7 @@ libxml2:
 macos_machine:
 - arm64-apple-darwin20.0.0
 openssl:
-- '3'
+- '3.1'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -11,7 +11,7 @@ krb5:
 libxml2:
 - '2.12'
 openssl:
-- '3'
+- '3.1'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,7 @@ source:
     - patches/libxml2_212_compat_const.patch
 
 build:
-  number: 4
+  number: 6
 
 requirements:
   build:


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
*  Reset the build number to `0` (if the version changed)
* :no_entry:  [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

Per request in https://github.com/conda-forge/postgresql-feedstock/pull/192#issuecomment-1841783540 , this PR (hopefully) hard-codes openssl to 3.1, so that we get a hopefully good build combo of postgresql 16.1 + openssl 3.1 + libxml2 2.12.   This sets the build number to 6 as I suspect 5 is going to be used by #192 .  No rerender will be done due to the manual setting of the ci_support files.  Hope I did this correct.  