### PR TITLE
Intermediate build with libxml2 2.11 and add run deps for libpq

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -23,7 +23,7 @@ krb5:
 libuuid:
 - '2'
 libxml2:
-- '2.12'
+- '2.11'
 openssl:
 - '3'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -27,7 +27,7 @@ krb5:
 libuuid:
 - '2'
 libxml2:
-- '2.12'
+- '2.11'
 openssl:
 - '3'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -23,7 +23,7 @@ krb5:
 libuuid:
 - '2'
 libxml2:
-- '2.12'
+- '2.11'
 openssl:
 - '3'
 pin_run_as_build:

--- a/.ci_support/migrations/libxml2212.yaml
+++ b/.ci_support/migrations/libxml2212.yaml
@@ -1,7 +1,0 @@
-__migrator:
-  build_number: 1
-  kind: version
-  migration_number: 1
-libxml2:
-- '2.12'
-migrator_ts: 1700445986.2150207

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -21,7 +21,7 @@ krb5:
 libuuid:
 - '2'
 libxml2:
-- '2.12'
+- '2.11'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 openssl:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -21,7 +21,7 @@ krb5:
 libuuid:
 - '2'
 libxml2:
-- '2.12'
+- '2.11'
 macos_machine:
 - arm64-apple-darwin20.0.0
 openssl:

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -9,7 +9,7 @@ cxx_compiler:
 krb5:
 - '1.21'
 libxml2:
-- '2.12'
+- '2.11'
 openssl:
 - '3'
 pin_run_as_build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,8 @@ source:
     - patches/fix_auth_setenv_win.patch  # [win]
     - patches/fix_x509_name_win.patch  # [win]
     - patches/fix_mac10_9_clock_realtime.patch  # [osx]
-    - patches/libxml2_212_compat_const.patch
+    # Temporary disabiling for intermediate build GH194
+    #- patches/libxml2_212_compat_const.patch
     # Fix openssl 3.2 compat issue likely to be fixed in 16.2
     - patches/fix_openssl32_compat.patch
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -149,7 +149,6 @@ outputs:
         - make                   # [unix]
         - pkg-config             # [unix]
       host:
-        - libxml2
         # these are here for sake of run_exports taking effect
         - krb5
         - openssl
@@ -158,14 +157,11 @@ outputs:
         # - readline             # [not win]
         - tzcode                 # [not win]
         - tzdata                 # [not win]
-        - zlib
         - msinttypes             # [win and float(vc) <14]
       run:
         # It seems necessary to add these to match other outputs
         - krb5
-        - libxml2
         - openssl
-        - zlib
     script: install_runtime.sh   # [unix]
     script: install_runtime.bat  # [win]
     test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -159,6 +159,12 @@ outputs:
         - tzdata                 # [not win]
         - zlib
         - msinttypes             # [win and float(vc) <14]
+      run:
+        # It seems necessary to add these to match other outputs
+        - krb5
+        - libxml2
+        - openssl
+        - zlib
     script: install_runtime.sh   # [unix]
     script: install_runtime.bat  # [win]
     test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,7 @@ source:
     - patches/fix_openssl32_compat.patch
 
 build:
-  number: 6
+  number: 7
 
 requirements:
   build:


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
*  Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

With the #191 fun, we ended up marking a number of builds as broken.

This PR intends to fix #194 by creating a resolvable dependency combination of openssl 3.2 and libxml2 2.11.  This should be rather straight forward giving that libxml2 2.12 is still in migration, so conda-forge pinning will pull in 2.11 on a rerender with the migration yaml removed in this PR.  This should allow packages like gdal=3.8.1 to be installable, see https://github.com/conda-forge/gdal-feedstock/issues/867

I am also including a fix that adds an explicit `run` dependency to the `libpq` output.  When we tried an intermediate build of openssl 3.1 with #193, we ended up with a `libpq` that needed patched see conda-forge/conda-forge-repodata-patches-feedstock#612

My TODO:
- [x] verify that the build logs show the build getting libxml2 2.11 and not 2.12, especially on OSX, which is part of the reason why we had all this pain this week to begin with.
- [x] review the logs for DSO issues with the new run deps for libpq
- [ ] create a followup PR that reapplies the libxml2 2.12 migration